### PR TITLE
Fix a compilation error of flycheck.tex

### DIFF
--- a/doc/flycheck.texi
+++ b/doc/flycheck.texi
@@ -83,7 +83,7 @@ checking for buffers.  It is intended as replacement for the older
 Flymake package which is built into Emacs.
 
 @xref{Introduction}, for more information about Flycheck.  For
-installations instructions and a quick tutorial, @pxref {Installation}
+installations instructions and a quick tutorial, @pxref{Installation}
 and @ref{Quickstart} respectively.  @xref{Usage}, for a detailed user
 guide.
 


### PR DESCRIPTION
Fix the following error:

```
flycheck.texi:86: @pxref expected braces.
flycheck.texi:86: ` {Installation}
and @ref{Quickstart} res...' is too long for expansion; not expanded.
flycheck.texi:86: First argument to cross-reference may not be empty.
/home/yuta/.emacs.d/el-get/flycheck/doc//flycheck.texi:75: Next reference to nonexistent node `Introduction' (perhaps incorrect sectioning?).
/home/yuta/.emacs.d/el-get/flycheck/doc//flycheck.texi:85: Cross reference to nonexistent node `Introduction' (perhaps incorrect sectioning?).
makeinfo: Removing output file `/home/yuta/.emacs.d/el-get/flycheck/doc/flycheck.info' due to errors; use --force to preserve.
```
